### PR TITLE
Incorporate RK4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SOURCES	 := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
 OBJECTS	 := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.$(OBJEXT)))
 
 #Default Make
-all: resources $(TARGET) run
+all: resources $(TARGET)
 
 #Remake
 remake: cleaner all
@@ -62,8 +62,8 @@ $(TARGET): $(OBJECTS)
 #Compile
 $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(INC) -c -o $@ $<
 	@$(CC) $(CFLAGS) $(INCDEP) -MM $(SRCDIR)/$*.$(SRCEXT) > $(BUILDDIR)/$*.$(DEPEXT)
+	$(CC) $(CFLAGS) $(INC) -c -o $@ $<
 	@sed -e ':a;N;$$!ba;s/ \\\\\\n//g' < $(BUILDDIR)/$*.$(DEPEXT) > $(BUILDDIR)/$*.$(DEPEXT).tmp # Account for gcc line-breaking long dependency files
 	@sed -e 's|.*:|$(BUILDDIR)/$*.$(OBJEXT):|' < $(BUILDDIR)/$*.$(DEPEXT).tmp > $(BUILDDIR)/$*.$(DEPEXT) # stick the builddir stem on the filename
 	@sed -e 's/.*://' -e 's/\\$$//' < $(BUILDDIR)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(BUILDDIR)/$*.$(DEPEXT) # split and add the files into new lines

--- a/clipboard.txt
+++ b/clipboard.txt
@@ -1,0 +1,4 @@
+
+$(CC) $(CFLAGS) $(INCDEP) -MM $(SRCDIR)/$*.$(SRCEXT) > $(BUILDDIR)/$*.$(DEPEXT)
+gcc -Wall -g -I$(INCDIR) -MM src/core/core.c > obj/core/core.d
+gcc -Wall -g -Iinc -MM src/core/core.c > obj/core/core.d

--- a/inc/core/physics.h
+++ b/inc/core/physics.h
@@ -77,7 +77,7 @@ void calcForces(Vector2 *forces, SoftBody sb, SBPoints points);
 void calcForce_springs(Vector2 *forces, SoftBody sb, SBPoints points);
 void calcForce_shape(Vector2 *forces, SoftBody sb, SBPoints points);
 void calcForce_pressure(Vector2 *forces, SoftBody sb, SBPoints points);
-SBPoints projectSB(SBPoints points, Vector2 *forces, float dt);
+void projectSB(SBPoints *dest, SBPoints src, Vector2 *forces, float dt);
 
 typedef struct SBPos {
         Vector2 position;

--- a/inc/core/physics.h
+++ b/inc/core/physics.h
@@ -25,6 +25,8 @@ typedef struct SoftBody {
         Vector2 *pointPos;
         Vector2 *pointVel;
         Vector2 *shape; // Make sure the frame is balanced (the average of the points is the origin), or else (i think) the body will move on its own
+        Vector2 shapePosition;
+        float shapeRotation;
         // Surfaces wind CCW mathematically, but because Y is inverted,
         // this means that on-screen they wind CW
         int numSurfaces;

--- a/inc/core/physics.h
+++ b/inc/core/physics.h
@@ -58,7 +58,8 @@ SoftBody createEmptySoftBody(
     float nRT);
 void freeSoftbody(SoftBody *toFree);
 
-// private util function
+// private util functions
+void _center_sb_shape(SoftBody *sb);
 void _alloc_sb(SoftBody *sb, int numPoints, int numSurfaces, int numSprings);
 
 void circleSoftbody(SoftBody *sb, Vector2 center, float radius, int numPoints);

--- a/inc/core/physics.h
+++ b/inc/core/physics.h
@@ -16,6 +16,7 @@ typedef struct BB {
 
 // Flags, can be both
 typedef enum SoftBodyType {
+        SoftBodyType_Springs = 0b100,
         SoftBodyType_Shape = 0b001,
         SoftBodyType_Pressure = 0b010,
 } SoftBodyType;
@@ -61,6 +62,37 @@ void freeSoftbody(SoftBody *toFree);
 // private util functions
 void _center_sb_shape(SoftBody *sb);
 void _alloc_sb(SoftBody *sb, int numPoints, int numSurfaces, int numSprings);
+
+// helpers for RK4
+// For the calcForce functions, they add onto a list of vectors with the
+// Forces on each point from each force. They use the SoftBody sb only
+// for it's parameters; they use the SBPoints points as the actual position
+// of the softbody
+typedef struct SBPoints {
+        int num;
+        Vector2 *pos;
+        Vector2 *vel;
+} SBPoints;
+void calcForces(Vector2 *forces, SoftBody sb, SBPoints points);
+void calcForce_springs(Vector2 *forces, SoftBody sb, SBPoints points);
+void calcForce_shape(Vector2 *forces, SoftBody sb, SBPoints points);
+void calcForce_pressure(Vector2 *forces, SoftBody sb, SBPoints points);
+SBPoints projectSB(SBPoints points, Vector2 *forces, float dt);
+
+typedef struct SBPos {
+        Vector2 position;
+        float rotation;
+} SBPos;
+// Calculates and stores the position and rotation of the softbody (as for shape matching)
+SBPos calcShape(SoftBody sb, SBPoints points);
+
+Vector2 *alloc_forces(int num);
+void sumForces(int num, Vector2 *forces, Vector2 *other, float multiplier);
+
+SBPoints rip_SBPoints(SoftBody sb);
+void apply_SBPoints(SoftBody *sb, SBPoints points);
+void alloc_SBPoints(SBPoints *points, int num);
+void free_SBPoints(SBPoints *points);
 
 void circleSoftbody(SoftBody *sb, Vector2 center, float radius, int numPoints);
 void rectSoftbody(SoftBody *sb, Vector2 center, Vector2 scale, int detailX, int detailY, bool makeTruss);

--- a/inc/debug.h
+++ b/inc/debug.h
@@ -3,6 +3,7 @@
 
 #include <core/physics.h>
 
+Color interpolate3way(Color A, Color B, Color C, float t);
 void DrawSoftbody_debug(SoftBody sb);
 
 #endif // DEBUG_H_

--- a/src/core/physics.c
+++ b/src/core/physics.c
@@ -81,7 +81,7 @@ SBPos calcShape(SoftBody sb, SBPoints points) { // Recalculate frame center and 
         float avg_rotation = 0;
         for (int i = 0; i < sb.numPoints; i++) {
                 // TODO: Fix this, as it averages not angles but rotations, but also that might be what we need, idk, put some more analysis/debugging into this line
-                avg_rotation += Vector2Angle(Vector2Add(sb.shape[i], avg_pos), points.pos[i]);
+                avg_rotation += Vector2Angle(sb.shape[i], Vector2Subtract(points.pos[i], avg_pos));
         }
         avg_rotation /= sb.numPoints;
 

--- a/src/core/physics.c
+++ b/src/core/physics.c
@@ -40,6 +40,9 @@ void update_SoftBody(SoftBody *sb, WorldValues worldValues, float dt) {
                 }
                 avg_rotation /= sb->numPoints;
 
+                sb->shapePosition = avg_pos;
+                sb->shapeRotation = avg_rotation;
+
                 Matrix shapeMatrix = MatrixIdentity();
                 float sinA = sinf(avg_rotation);
                 float cosA = cosf(avg_rotation);

--- a/src/core/physics.c
+++ b/src/core/physics.c
@@ -33,7 +33,7 @@ void update_SoftBody(SoftBody *sb, WorldValues worldValues, float dt) {
                         avg_pos.x += sb->pointPos[i].x;
                         avg_pos.y += sb->pointPos[i].y;
                 }
-                avg_pos = Vector2Scale(avg_pos, 1 / sb->numPoints);
+                avg_pos = Vector2Scale(avg_pos, 1.f / sb->numPoints);
                 float avg_rotation = 0;
                 for (int i = 0; i < sb->numPoints; i++) {
                         avg_rotation += Vector2Angle(Vector2Add(sb->shape[i], avg_pos), sb->pointPos[i]);
@@ -156,6 +156,8 @@ void circleSoftbody(SoftBody *sb, Vector2 center, float radius, int numPoints) {
         }
         sb->surfaceB[numPoints - 1] = 0;
         sb->springB[numPoints - 1] = 0;
+
+        _center_sb_shape(sb);
 }
 
 // Recommended to just do shape matching.
@@ -334,6 +336,8 @@ void rectSoftbody(SoftBody *sb, Vector2 center, Vector2 scale, int detailX, int 
                 sb->surfaceB[pt - 1] = 0;
                 sb->springB[pt - 1] = 0;
         }
+
+        _center_sb_shape(sb);
 }
 
 SoftBody createEmptySoftBody(SoftBodyType type, float mass, float linearDrag, float springStrength, float springDamp, float shapeSpringStrength, float nRT) {
@@ -351,7 +355,21 @@ SoftBody createEmptySoftBody(SoftBodyType type, float mass, float linearDrag, fl
         };
 }
 
+void _center_sb_shape(SoftBody *sb) {
+        Vector2 avg_pos = {0, 0};
+        for (int i = 0; i < sb->numPoints; i++) {
+                avg_pos.x += sb->shape[i].x;
+                avg_pos.y += sb->shape[i].y;
+        }
+        avg_pos = Vector2Scale(avg_pos, 1.f / sb->numPoints);
+        for (int i = 0; i < sb->numPoints; i++) {
+                sb->shape[i].x -= avg_pos.x;
+                sb->shape[i].y -= avg_pos.y;
+        }
+}
+
 void _alloc_sb(SoftBody *sb, int numPoints, int numSurfaces, int numSprings) {
+
         sb->numPoints = numPoints;
         sb->pointPos = MemAlloc(sizeof(Vector2) * numPoints);
         sb->pointVel = MemAlloc(sizeof(Vector2) * numPoints);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,6 +1,25 @@
 #include "debug.h"
+#include <stdlib.h>
 
 void DrawSoftbody_debug(SoftBody sb) {
+        // Draw shape
+
+        Matrix shapeMatrix = MatrixIdentity();
+        float sinA = sinf(sb.shapeRotation);
+        float cosA = cosf(sb.shapeRotation);
+        shapeMatrix.m0 = cosA;
+        shapeMatrix.m1 = sinA;
+        shapeMatrix.m4 = -sinA;
+        shapeMatrix.m5 = cosA;
+        Vector2 *shapePos = alloca(sizeof(Vector2) * sb.numPoints);
+        for (int i = 0; i < sb.numPoints; i++) {
+                shapePos[i] = Vector2Add(Vector2Transform(sb.shape[i], shapeMatrix), sb.shapePosition);
+        }
+        for (int i = 0; i < sb.numPoints; i++) {
+                // Line
+                DrawLineEx(shapePos[i], shapePos[(i + 1) % sb.numPoints], 0.1f, GRAY);
+                DrawLineEx(shapePos[i], sb.pointPos[i], 0.15f, YELLOW);
+        }
         // Draw Springs
         for (int i = 0; i < sb.numSprings; i++) {
                 DrawLineEx(sb.pointPos[sb.springA[i]], sb.pointPos[sb.springB[i]], 0.15f, YELLOW);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,6 +1,31 @@
 #include "debug.h"
 #include <stdlib.h>
 
+inline float I3WHF(unsigned char a, unsigned char b, float t) __attribute__((always_inline));
+float I3WHF(unsigned char a, unsigned char b, float t) {
+        return a + (b - a) * t;
+}
+
+Color interpolate3way(Color A, Color B, Color C, float t) {
+        if (t <= -1.f)
+                return A;
+        else if (t >= 1.f)
+                return C;
+        else if (t < 0.f)
+                return (Color){
+                    .r = I3WHF(A.r, B.r, t + 1.f),
+                    .g = I3WHF(A.g, B.g, t + 1.f),
+                    .b = I3WHF(A.b, B.b, t + 1.f),
+                    .a = I3WHF(A.a, B.a, t + 1.f),
+                };
+        return (Color){
+            .r = I3WHF(B.r, C.r, t),
+            .g = I3WHF(B.g, C.g, t),
+            .b = I3WHF(B.b, C.b, t),
+            .a = I3WHF(B.a, C.a, t),
+        };
+}
+
 void DrawSoftbody_debug(SoftBody sb) {
         // Draw shape
 
@@ -22,7 +47,8 @@ void DrawSoftbody_debug(SoftBody sb) {
         }
         // Draw Springs
         for (int i = 0; i < sb.numSprings; i++) {
-                DrawLineEx(sb.pointPos[sb.springA[i]], sb.pointPos[sb.springB[i]], 0.15f, YELLOW);
+                DrawLineEx(sb.pointPos[sb.springA[i]], sb.pointPos[sb.springB[i]], 0.15f,
+                           interpolate3way(RED, GREEN, RED, sb.lengths[i] - Vector2Distance(sb.pointPos[sb.springA[i]], sb.pointPos[sb.springB[i]])));
         }
         // Draw surfaces
         for (int i = 0; i < sb.numSurfaces; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -13,12 +13,24 @@ int main() {
         InitWindow(screenWidth, screenHeight, "Test Platformer");
         SetTargetFPS(60);
 
-        Vector2 gravity = {0, 20};
+        WorldValues worldValues = {.gravity = {0, 0}};
 
         MyCam camera = createCamera((Vector2){0, 0}, 10.0, screenWidth, screenHeight, 0.0);
 
-        SoftBody body = createEmptySoftBody(SoftBodyType_Pressure, 10, 1, 1, 1, 1, 1);
-        rectSoftbody(&body, (Vector2){0, 0}, (Vector2){1.0, 1.0}, 2, 2, false);
+        SoftBody body1 = createEmptySoftBody(
+            SoftBodyType_Springs | SoftBodyType_Pressure | SoftBodyType_Shape, // type
+            1.f,                                                               // mass
+            1.f,                                                               // drag
+            10.f,                                                              // spring strength
+            1.f,                                                               // spring dampening
+            1.f,                                                               // shape spring strength
+            10.f                                                               // nRT
+        );
+        // circleSoftbody(&body1, (Vector2){-3.0, 0}, 2.0, 10);
+        rectSoftbody(&body1, (Vector2){-2.5, -1.5}, (Vector2){5.0, 3.0}, 5, 3, true);
+
+        // SoftBody body2 = createEmptySoftBody(SoftBodyType_Pressure, 10, 1, 10, 1, 1, 10);
+        // circleSoftbody(&body2, (Vector2){3.0, 0}, 2.0, 10);
 
         while (!WindowShouldClose()) {
                 BeginDrawing();
@@ -26,17 +38,46 @@ int main() {
 
                 float dt = GetFrameTime();
 
+                // testspeedmultiplier
+                float testspeedmultiplier =
+                    IsKeyDown(KEY_ZERO)    ? 1.0f
+                    : IsKeyDown(KEY_NINE)  ? .9f
+                    : IsKeyDown(KEY_EIGHT) ? .8f
+                    : IsKeyDown(KEY_SEVEN) ? .7f
+                    : IsKeyDown(KEY_SIX)   ? .6f
+                    : IsKeyDown(KEY_FIVE)  ? .5f
+                    : IsKeyDown(KEY_FOUR)  ? .4f
+                    : IsKeyDown(KEY_THREE) ? .3f
+                    : IsKeyDown(KEY_TWO)   ? .2f
+                    : IsKeyDown(KEY_ONE)   ? .1f
+                                           : 0.0f;
+
+                update_SoftBody(&body1, worldValues, dt * testspeedmultiplier);
+                // update_SoftBody(&body2, worldValues, dt);
+
                 BeginMode2D(camera.raylib_cam);
                 /* Draw Stuff Here */
-                DrawSoftbody_debug(body);
+                DrawSoftbody_debug(body1);
+                // DrawSoftbody_debug(body2);
 
                 EndMode2D();
 
-                DrawText("It Works!", 20, 20, 20, BLACK);
+                float V = 0.f;
+                for (int i = 0; i < body1.numSurfaces; i++) {
+                        Vector2 a = body1.pointPos[body1.surfaceA[i]];
+                        Vector2 b = body1.pointPos[body1.surfaceB[i]];
+                        V += a.x * b.y - a.y * b.x;
+                }
+                V *= 0.5f;
+
+                DrawText(TextFormat("%.4f, %.4f", body1.shapePosition.x, body1.shapePosition.y), 20, 20, 20, BLACK);
+                DrawText(TextFormat("Simulation Speed %0.1fx", testspeedmultiplier), 20, 40, 20, BLACK);
+                DrawText(TextFormat("Volume: %f", V), 20, 60, 20, BLACK);
                 EndDrawing();
         }
 
-        freeSoftbody(&body);
+        freeSoftbody(&body1);
+        // freeSoftbody(&body2);
         CloseWindow();
         return 0;
 }


### PR DESCRIPTION
Make the physics engine start use an RK4 physics system instead of Euler's method, greatly improving stability, as necessary for the extremely unstable nature of this style of softbody simulation.